### PR TITLE
Fix/file paths with spaces

### DIFF
--- a/run.py
+++ b/run.py
@@ -15,5 +15,4 @@ if __name__ == '__main__':
     # Use the python interpreter inside the virtual environment.
     vpython = get_vbin('python')
     run_script = normpath(f'{rootdir}/_run.py')
-    print(f'Running: {vpython} {run_script} {" ".join(argv)}')
     system(f'{vpython} {run_script} {" ".join(argv)}')

--- a/run.py
+++ b/run.py
@@ -10,7 +10,10 @@ from rcan.utility import get_vbin, rootdir
 # environment.
 if __name__ == '__main__':
 
+    # Keep/add double quotes around path with space.
+    argv = [f'"{x}"' if ' ' in x else x for x in sys.argv[1:]]
     # Use the python interpreter inside the virtual environment.
     vpython = get_vbin('python')
     run_script = normpath(f'{rootdir}/_run.py')
-    system(f'{vpython} {run_script} {" ".join(sys.argv[1:])}')
+    print(f'Running: {vpython} {run_script} {" ".join(argv)}')
+    system(f'{vpython} {run_script} {" ".join(argv)}')


### PR DESCRIPTION
Correctly handles path to images with spaces if double-quoted.

Before:
```shell
python run.py --chop --scale 2 --outdir '.' --cpu "C:/Users/x/Pictures/Angele 002 small.png"
Some files were not found or unreadable:
C:/Users/x/Pictures/Angele
002
small.png
```

After:
```shell
C:\Users\x\Documents\user-friendly-RCAN>python run.py --chop --scale 2 --outdir '.' --cpu "C:/Users/x/Pictures/Angele 002 small.png"
Loading model from C:\Users\x\Documents\user-friendly-RCAN\data\model\RCAN_BIX2.pt
100%|#############################################| 1/1 [00:39<00:00, 39.47s/it]
Saved result:
C:\Users\x\Documents\user-friendly-RCAN\Angele 002 small RCAN x2.png
```